### PR TITLE
Inactive rssi to OSD

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -25,8 +25,8 @@
 #define FC_FIRMWARE_NAME            "Betaflight"
 #define FC_FIRMWARE_IDENTIFIER      "BTFL"
 #define FC_VERSION_MAJOR            4  // increment when a major release is made (big new feature, etc)
-#define FC_VERSION_MINOR            6  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      0  // increment when a bug is fixed
+#define FC_VERSION_MINOR            5  // increment when a minor release is made (small new feature, change etc)
+#define FC_VERSION_PATCH_LEVEL      2  // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1596,7 +1596,7 @@ static void osdElementRssiDbm(osdElementParms_t *element)
     const int8_t antenna = getActiveAntenna();
     const int16_t osdRssiDbm = getRssiDbm();
     const int16_t osdRssiDbmInactive = getRssiDbmInactive();
-    static bool diversity = false;
+    const bool diversity = getIsDiversity();
 
     if (fmax(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
          element->attr = DISPLAYPORT_SEVERITY_CRITICAL;
@@ -1605,8 +1605,7 @@ static void osdElementRssiDbm(osdElementParms_t *element)
         element->attr = DISPLAYPORT_SEVERITY_WARNING;
     }
 
-    if (antenna || diversity) {
-        diversity = true;
+    if (diversity) {
         tfp_sprintf(element->buff, "%c%3d:%d/%3d", SYM_RSSI, osdRssiDbm, antenna + 1, osdRssiDbmInactive);
     } else {
         tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, osdRssiDbm);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1595,15 +1595,19 @@ static void osdElementRssiDbm(osdElementParms_t *element)
 {
     const int8_t antenna = getActiveAntenna();
     const int16_t osdRssiDbm = getRssiDbm();
+    const int16_t osdRssiDbmInactive = getRssiDbmInactive();
     static bool diversity = false;
 
-    if (osdRssiDbm < osdConfig()->rssi_dbm_alarm) {
+    if (fmin(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
+        element->attr = DISPLAYPORT_SEVERITY_WARNING;
+    } else
+    if (fmax(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
         element->attr = DISPLAYPORT_SEVERITY_CRITICAL;
     }
 
     if (antenna || diversity) {
         diversity = true;
-        tfp_sprintf(element->buff, "%c%3d:%d", SYM_RSSI, osdRssiDbm, antenna + 1);
+        tfp_sprintf(element->buff, "%c%3d:%d/%3d", SYM_RSSI, osdRssiDbm, antenna + 1, osdRssiDbmInactive);
     } else {
         tfp_sprintf(element->buff, "%c%3d", SYM_RSSI, osdRssiDbm);
     }

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1598,11 +1598,11 @@ static void osdElementRssiDbm(osdElementParms_t *element)
     const int16_t osdRssiDbmInactive = getRssiDbmInactive();
     static bool diversity = false;
 
+    if (fmax(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
+         element->attr = DISPLAYPORT_SEVERITY_CRITICAL;
+    } else
     if (fmin(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
         element->attr = DISPLAYPORT_SEVERITY_WARNING;
-    } else
-    if (fmax(osdRssiDbm, osdRssiDbmInactive) < osdConfig()->rssi_dbm_alarm) {
-        element->attr = DISPLAYPORT_SEVERITY_CRITICAL;
     }
 
     if (antenna || diversity) {

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -71,6 +71,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 {
     const batteryState_e batteryState = getBatteryState();
     const timeUs_t currentTimeUs = micros();
+    const bool diversity = getIsDiversity();
 
     static timeUs_t armingDisabledUpdateTimeUs;
     static armingDisableFlags_e armingDisabledDisplayFlag = 0;
@@ -180,7 +181,13 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
     }
 #ifdef USE_RX_RSSI_DBM
     // rssi dbm
-    if (osdWarnGetState(OSD_WARNING_RSSI_DBM) && (getRssiDbm() < osdConfig()->rssi_dbm_alarm)) {
+    if (
+        osdWarnGetState(OSD_WARNING_RSSI_DBM) &&
+        (
+            (!diversity && getRssiDbm() < osdConfig()->rssi_dbm_alarm) ||
+            (diversity && fmax(getRssiDbm(), getRssiDbmInactive()) < osdConfig()->rssi_dbm_alarm)
+        )
+    ) {
         tfp_sprintf(warningText, "RSSI DBM");
         *displayAttr = DISPLAYPORT_SEVERITY_CRITICAL;
         *blinking = true;

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -185,7 +185,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         osdWarnGetState(OSD_WARNING_RSSI_DBM) &&
         (
             (!diversity && getRssiDbm() < osdConfig()->rssi_dbm_alarm) ||
-            (diversity && fmax(getRssiDbm(), getRssiDbmInactive()) < osdConfig()->rssi_dbm_alarm)
+            (diversity && MAX(getRssiDbm(), getRssiDbmInactive()) < osdConfig()->rssi_dbm_alarm)
         )
     ) {
         tfp_sprintf(warningText, "RSSI DBM");

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -233,6 +233,7 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
     }
 #ifdef USE_RX_RSSI_DBM
     setRssiDbm(rssiDbm, RSSI_SOURCE_RX_PROTOCOL_CRSF);
+    setRssiDbmInactive(-1 * (stats.active_antenna ? stats.uplink_RSSI_1 : stats.uplink_RSSI_2), RSSI_SOURCE_RX_PROTOCOL_CRSF);
     setActiveAntenna(stats.active_antenna);
 #endif
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -80,7 +80,9 @@ static timeUs_t lastRssiSmoothingUs = 0;
 #ifdef USE_RX_RSSI_DBM
 static int8_t activeAntenna;
 static int16_t rssiDbm = CRSF_RSSI_MIN;    // range: [-130,0]
+static int16_t rssiDbmInactive = CRSF_RSSI_MIN;    // range: [-130,0]
 static int16_t rssiDbmRaw = CRSF_RSSI_MIN; // range: [-130,0]
+static int16_t rssiDbmRawInactive = CRSF_RSSI_MIN; // range: [-130,0]
 #endif //USE_RX_RSSI_DBM
 #ifdef USE_RX_RSNR
 static int16_t rsnr = CRSF_SNR_MIN;        // range: [-30,20]
@@ -908,6 +910,10 @@ void updateRSSI(timeUs_t currentTimeUs)
                 pt1FilterUpdateCutoff(&rssiDbmFilter, k2);
                 rssiDbm = pt1FilterApply(&rssiDbmFilter, rssiDbmRaw);
             }
+            if (rssiDbmInactive != rssiDbmRawInactive) {
+                pt1FilterUpdateCutoff(&rssiDbmFilter, k2);
+                rssiDbmInactive = pt1FilterApply(&rssiDbmFilter, rssiDbmRawInactive);
+            }
 #endif //USE_RX_RSSI_DBM
 
 #ifdef USE_RX_RSNR
@@ -945,6 +951,11 @@ int16_t getRssiDbm(void)
     return rssiDbm;
 }
 
+int16_t getRssiDbmInactive(void)
+{
+    return rssiDbmRawInactive;
+}
+
 void setRssiDbm(int16_t rssiDbmValue, rssiSource_e source)
 {
     if (source != rssiSource) {
@@ -952,6 +963,15 @@ void setRssiDbm(int16_t rssiDbmValue, rssiSource_e source)
     }
 
     rssiDbmRaw = rssiDbmValue;
+}
+
+void setRssiDbmInactive(int16_t rssiDbmValue, rssiSource_e source)
+{
+    if (source != rssiSource) {
+        return;
+    }
+
+    rssiDbmRawInactive = rssiDbmValue;
 }
 
 void setRssiDbmDirect(int16_t newRssiDbm, rssiSource_e source)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -83,6 +83,7 @@ static int16_t rssiDbm = CRSF_RSSI_MIN;    // range: [-130,0]
 static int16_t rssiDbmInactive = CRSF_RSSI_MIN;    // range: [-130,0]
 static int16_t rssiDbmRaw = CRSF_RSSI_MIN; // range: [-130,0]
 static int16_t rssiDbmRawInactive = CRSF_RSSI_MIN; // range: [-130,0]
+static bool diversity = false;
 #endif //USE_RX_RSSI_DBM
 #ifdef USE_RX_RSNR
 static int16_t rsnr = CRSF_SNR_MIN;        // range: [-30,20]
@@ -958,6 +959,11 @@ int16_t getRssiDbmInactive(void)
     return rssiDbmInactive;
 }
 
+bool getIsDiversity(void)
+{
+    return diversity;
+}
+
 void setRssiDbm(int16_t rssiDbmValue, rssiSource_e source)
 {
     if (source != rssiSource) {
@@ -972,7 +978,7 @@ void setRssiDbmInactive(int16_t rssiDbmValue, rssiSource_e source)
     if (source != rssiSource) {
         return;
     }
-
+    diversity = true;
     rssiDbmRawInactive = rssiDbmValue;
 }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -94,6 +94,7 @@ static pt1Filter_t frameErrFilter;
 static pt1Filter_t rssiFilter;
 #ifdef USE_RX_RSSI_DBM
 static pt1Filter_t rssiDbmFilter;
+static pt1Filter_t rssiDbmInactiveFilter;
 #endif //USE_RX_RSSI_DBM
 #ifdef USE_RX_RSNR
 static pt1Filter_t rsnrFilter;
@@ -389,6 +390,7 @@ void rxInit(void)
 
 #ifdef USE_RX_RSSI_DBM
     pt1FilterInit(&rssiDbmFilter, k);
+    pt1FilterInit(&rssiDbmInactiveFilter, k);
 #endif //USE_RX_RSSI_DBM
 
 #ifdef USE_RX_RSNR
@@ -911,8 +913,8 @@ void updateRSSI(timeUs_t currentTimeUs)
                 rssiDbm = pt1FilterApply(&rssiDbmFilter, rssiDbmRaw);
             }
             if (rssiDbmInactive != rssiDbmRawInactive) {
-                pt1FilterUpdateCutoff(&rssiDbmFilter, k2);
-                rssiDbmInactive = pt1FilterApply(&rssiDbmFilter, rssiDbmRawInactive);
+                pt1FilterUpdateCutoff(&rssiDbmInactiveFilter, k2);
+                rssiDbmInactive = pt1FilterApply(&rssiDbmInactiveFilter, rssiDbmRawInactive);
             }
 #endif //USE_RX_RSSI_DBM
 
@@ -953,7 +955,7 @@ int16_t getRssiDbm(void)
 
 int16_t getRssiDbmInactive(void)
 {
-    return rssiDbmRawInactive;
+    return rssiDbmInactive;
 }
 
 void setRssiDbm(int16_t rssiDbmValue, rssiSource_e source)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -206,6 +206,7 @@ void setRssiDbmInactive(int16_t newRssiDbm, rssiSource_e source);
 void setRssiDbmDirect(int16_t newRssiDbm, rssiSource_e source);
 int8_t getActiveAntenna(void);
 void setActiveAntenna(int8_t antenna);
+bool getIsDiversity(void);
 #endif //USE_RX_RSSI_DBM
 
 #ifdef USE_RX_RSNR

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -201,6 +201,8 @@ uint16_t rxGetLinkQualityPercent(void);
 #ifdef USE_RX_RSSI_DBM
 int16_t getRssiDbm(void);
 void setRssiDbm(int16_t newRssiDbm, rssiSource_e source);
+int16_t getRssiDbmInactive(void);
+void setRssiDbmInactive(int16_t newRssiDbm, rssiSource_e source);
 void setRssiDbmDirect(int16_t newRssiDbm, rssiSource_e source);
 int8_t getActiveAntenna(void);
 void setActiveAntenna(int8_t antenna);


### PR DESCRIPTION
- Add inactive antenna rssi dbm to OSD;
- Show rssi warring color if one rssi is bad;
- Show rssi alert color if every rssi is bad;
- Support diversity in rssi dbm alert.